### PR TITLE
GTK3 toolbar icons size is too big

### DIFF
--- a/data/geany.css
+++ b/data/geany.css
@@ -59,3 +59,8 @@ statusbar {
 	margin: -6px 0;
 }
 */
+
+button {
+	margin: 0;
+	padding: 0;
+}


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/282214/164250230-dc3d49e9-54a3-49f3-acd6-b28851a25614.png)

After

![image](https://user-images.githubusercontent.com/282214/164250349-1fa93b33-5714-4b2b-9e13-290c6e785d91.png)
